### PR TITLE
fix: correct lockpicking event name

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -9,7 +9,7 @@ lib.callback.register('cat_lockpick:getClosestVehicle', function()
     end
 end)
 
-lib.callback.register('cat_lockpick:startLockpiking', function(vehicle)
+lib.callback.register('cat_lockpick:startLockpicking', function(vehicle)
     if Config.EnableAlarm == true then
         SetVehicleAlarm(vehicle, true)
         SetVehicleAlarmTimeLeft(vehicle, Config.AlarmTimer * 1000)

--- a/server.lua
+++ b/server.lua
@@ -13,7 +13,7 @@ CreateThread(function()
 
                 if closestVehicle ~= nil then
                     if lockstatus == 2 then
-                        local success = lib.callback.await('cat_lockpick:startLockpiking', source, closestVehicle)
+                        local success = lib.callback.await('cat_lockpick:startLockpicking', source, closestVehicle)
 
                         if Config.RemoveLockpickOnUse == true then
                             if Config.RemoveOnlyOnFailure == true then
@@ -44,7 +44,7 @@ CreateThread(function()
 
                 if closestVehicle ~= nil then
                     if lockstatus == 2 then
-                        local success = lib.callback.await('cat_lockpick:startLockpiking', source, closestVehicle)
+                        local success = lib.callback.await('cat_lockpick:startLockpicking', source, closestVehicle)
 
                         if Config.RemoveLockpickOnUse == true then
                             if Config.RemoveOnlyOnFailure == true then


### PR DESCRIPTION
## Summary
- fix typo in lockpicking event name so client/server match

## Testing
- `luac -p client.lua server.lua`
- `lua <test script>`

------
https://chatgpt.com/codex/tasks/task_e_689f7dc9e97883339aa10747ac917734